### PR TITLE
Added 'koa-cors'.

### DIFF
--- a/bin/x-mocks
+++ b/bin/x-mocks
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 
 var koa = require('koa'),
+  cors  = require('koa-cors'),
   route = require('koa-route'),
   app = module.exports = koa(),
   scanner = require('../lib/scanner.js')(app);
+
+app.use(cors());
 
 app.use(route.get('/routes', function*() {
   this.body = JSON.stringify(scanner.routes);

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "main": "app.js",
   "dependencies": {
     "koa": "~1.1.2",
+    "koa-cors": "0.0.16",
+    "koa-route": "~2.4.2",
+    "lodash-node": "~3.10.1",
     "mocha": "~2.3.4",
     "mock-fs": "~3.6.0",
-    "simple-mock": "~0.5.0",
-    "koa-route": "~2.4.2",
-    "lodash-node": "~3.10.1"
+    "simple-mock": "~0.5.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Adding `cors` enables outsource applications(generally front-end apps) to consume the exposed mocks routes.